### PR TITLE
Configurable header name for authentication

### DIFF
--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -24,6 +24,7 @@ env = Env()
 DEFAULTS = {
     'JWT_ALGORITHM': env('JWT_ALGORITHM', default='HS256'),
     'JWT_AUDIENCE': env('JWT_AUDIENCE', default=None),
+    'JWT_AUTH_HEADER': env('JWT_AUTH_HEADER', default='HTTP_AUTHORIZATION'),
     'JWT_AUTH_HEADER_PREFIX': env('JWT_AUTH_HEADER_PREFIX', default='JWT'),
     'JWT_ISSUER': env('JWT_ISSUER', default=None),
     'JWT_LEEWAY': env.timedelta('JWT_LEEWAY', 0),

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -56,7 +56,7 @@ def jwt_decode(token, context=None):
 
 
 def get_authorization_header(request):
-    auth = request.META.get('HTTP_AUTHORIZATION', '').split()
+    auth = request.META.get(jwt_settings.JWT_AUTH_HEADER, '').split()
     prefix = jwt_settings.JWT_AUTH_HEADER_PREFIX
 
     if len(auth) != 2 or auth[0].lower() != prefix.lower():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,6 +45,17 @@ class UtilsTests(UserTestCase):
 
         self.assertIsNone(header)
 
+    @override_jwt_settings(JWT_AUTH_HEADER='HTTP_AUTHORIZATION_TOKEN')
+    def test_custom_authorization_header(self):
+        headers = {
+            'HTTP_AUTHORIZATION_TOKEN': 'JWT token',
+        }
+
+        request = self.factory.get('/', **headers)
+        header = utils.get_authorization_header(request)
+
+        self.assertEqual(header, 'token')
+
     @override_jwt_settings(
         JWT_VERIFY_EXPIRATION=True,
         JWT_EXPIRATION_DELTA=timedelta(seconds=-1))


### PR DESCRIPTION
Allow developers to change the header name which is used to send the authentication token. As for now only the hardcoded `HTTP_AUTHORIZATION` is supported which covers most of the use cases, but not all of them. In the current project I've encountered a problem where `HTTP_AUTHORIZATION` is used to send Basic access authentication like: `Authorization: Basic c29ma+Buayx71`, so there is no option to include the `JWT` token in here. It would be great if the header could be changed through env variable and that's why I'm opening this PR.