### PR TITLE
Let the user parametrize the user's username field as a payload claim

### DIFF
--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from importlib import import_module
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test.signals import setting_changed
 from django.utils import six
 
@@ -53,6 +54,10 @@ DEFAULTS = {
     'JWT_PAYLOAD_HANDLER': env(
         'JWT_PAYLOAD_HANDLER',
         default='graphql_jwt.utils.jwt_payload'),
+    'JWT_USERNAME_CLAIM': env(
+        'JWT_USERNAME_CLAIM',
+        default=get_user_model().USERNAME_FIELD,
+    ),
 }
 
 IMPORT_STRINGS = (

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -85,7 +85,7 @@ def get_user_by_natural_key(user_id):
 
 
 def get_user_by_payload(payload):
-    username = payload.get(get_user_model().USERNAME_FIELD)
+    username = payload.get(jwt_settings.JWT_USERNAME_CLAIM)
 
     if not username:
         raise GraphQLJWTError(_('Invalid payload'))


### PR DESCRIPTION
## Background

Using Auth0, I'd like to be able to specify a token payload claim to look the username for, `sub` in my case.

## Suggested modification

Add a setting to specify which claim is used, by default `get_user_model().USERNAME_FIELD`.

@mongkok waiting for your input :)