### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from io import open
 import os
 import re
 
@@ -8,7 +9,7 @@ from setuptools import find_packages, setup
 
 def get_long_description():
     for filename in ('README.rst',):
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             yield f.read()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from io import open
 import os
 import re
+from io import open
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
Otherwise, the build fails with an encoding error due to the default locale being ASCII on the Debian builders, not UTF-8. Regardless, this is the recommended approach for writing a setup.py which supports both Python 2 and Python 3.

Similar problem:
https://github.com/pytest-dev/pytest-mock/pull/107