### PR TITLE
Add AuthenticationMiddleware settings to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,15 @@ Install last stable version from Pypi:
 
     pip install django-graphql-jwt
 
+Add ``AuthenticationMiddleware`` middleware to your *MIDDLEWARE* settings:
+
+.. code:: python
+
+    MIDDLEWARE = [
+        ...
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ...
+    ]
 
 Add ``JSONWebTokenMiddleware`` middleware to your *GRAPHENE* settings:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,6 +14,15 @@ Install last stable version v\ |version| from Pypi::
 
     pip install django-graphql-jwt
 
+Add ``AuthenticationMiddleware`` middleware to your *MIDDLEWARE* settings:
+
+.. code:: python
+
+    MIDDLEWARE = [
+        ...
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        ...
+    ]
 
 Add ``JSONWebTokenMiddleware`` middleware to your *GRAPHENE* settings::
 


### PR DESCRIPTION
```AuthenticationMiddleware``` is required for django-graphql-jwt, this PR adds how to setup ```AuthenticationMiddleware``` in django settings.
