### PR TITLE
Allow hashed refresh tokens

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -165,6 +165,14 @@ JWT_REFRESH_EXPIRED_HANDLER
   .. autofunction:: graphql_jwt.utils.refresh_has_expired
 
 
+JWT_GET_REFRESH_TOKEN_HANDLER
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  A custom function to retrieve a long time refresh token instance
+
+  .. autofunction:: graphql_jwt.refresh_token.utils.get_refresh_token_by_model
+
+
 Permissions
 -----------
 

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -68,7 +68,8 @@ def token_auth(f):
             payload.token = get_token(user, info.context)
 
             if jwt_settings.JWT_LONG_RUNNING_REFRESH_TOKEN:
-                payload.refresh_token = create_refresh_token(user).token
+                refresh_token = create_refresh_token(user)
+                payload.refresh_token = refresh_token._cached_token
 
             return payload
 

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -68,8 +68,7 @@ def token_auth(f):
             payload.token = get_token(user, info.context)
 
             if jwt_settings.JWT_LONG_RUNNING_REFRESH_TOKEN:
-                refresh_token = create_refresh_token(user)
-                payload.refresh_token = refresh_token._cached_token
+                payload.refresh_token = create_refresh_token(user).get_token()
 
             return payload
 

--- a/graphql_jwt/refresh_token/management/commands/cleartokens.py
+++ b/graphql_jwt/refresh_token/management/commands/cleartokens.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 from django.template.defaultfilters import pluralize
 
-from ...shortcuts import get_refresh_token_model
+from ...utils import get_refresh_token_model
 
 
 class Command(BaseCommand):

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -17,7 +17,7 @@ class RefreshTokenMixin(object):
     @classmethod
     def refresh(cls, root, info, refresh_token, **kwargs):
         context = info.context
-        refresh_token = get_refresh_token(refresh_token)
+        refresh_token = get_refresh_token(refresh_token, info.context)
 
         if refresh_token.is_expired(context):
             raise exceptions.JSONWebTokenError(_('Refresh token is expired'))

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -24,7 +24,7 @@ class RefreshTokenMixin(object):
 
         payload = jwt_settings.JWT_PAYLOAD_HANDLER(refresh_token.user, context)
         token = jwt_settings.JWT_ENCODE_HANDLER(payload, context)
-        refreshed_token = refresh_token.rotate()._cached_token
+        refreshed_token = refresh_token.rotate().get_token()
         return cls(token=token, payload=payload, refresh_token=refreshed_token)
 
 

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -34,7 +34,6 @@ class RevokeMixin(object):
 
     @classmethod
     def revoke(cls, root, info, refresh_token, **kwargs):
-        refresh_token = get_refresh_token(refresh_token)
+        refresh_token = get_refresh_token(refresh_token, info.context)
         refresh_token.revoke()
-
         return cls(revoked=timegm(refresh_token.revoked.timetuple()))

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -24,8 +24,7 @@ class RefreshTokenMixin(object):
 
         payload = jwt_settings.JWT_PAYLOAD_HANDLER(refresh_token.user, context)
         token = jwt_settings.JWT_ENCODE_HANDLER(payload, context)
-        refreshed_token = refresh_token.rotate().token
-
+        refreshed_token = refresh_token.rotate()._cached_token
         return cls(token=token, payload=payload, refresh_token=refreshed_token)
 
 

--- a/graphql_jwt/refresh_token/models.py
+++ b/graphql_jwt/refresh_token/models.py
@@ -41,8 +41,9 @@ class AbstractRefreshToken(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.token:
-            self.token = self.generate_token()
-        return super(AbstractRefreshToken, self).save(*args, **kwargs)
+            self.token = self._cached_token = self.generate_token()
+
+        super(AbstractRefreshToken, self).save(*args, **kwargs)
 
     def generate_token(self):
         return binascii.hexlify(

--- a/graphql_jwt/refresh_token/models.py
+++ b/graphql_jwt/refresh_token/models.py
@@ -50,6 +50,11 @@ class AbstractRefreshToken(models.Model):
             os.urandom(jwt_settings.JWT_REFRESH_TOKEN_N_BYTES),
         ).decode()
 
+    def get_token(self):
+        if hasattr(self, '_cached_token'):
+            return self._cached_token
+        return self.token
+
     def is_expired(self, context=None):
         orig_iat = timegm(self.created.timetuple())
         return jwt_settings.JWT_REFRESH_EXPIRED_HANDLER(orig_iat, context)

--- a/graphql_jwt/refresh_token/shortcuts.py
+++ b/graphql_jwt/refresh_token/shortcuts.py
@@ -1,14 +1,15 @@
 from django.utils.translation import ugettext as _
 
 from ..exceptions import JSONWebTokenError
-from .utils import get_refresh_token_by_model, get_refresh_token_model
+from ..settings import jwt_settings
+from .utils import get_refresh_token_model
 
 
 def get_refresh_token(token, context=None):
     RefreshToken = get_refresh_token_model()
 
     try:
-        return get_refresh_token_by_model(
+        return jwt_settings.JWT_GET_REFRESH_TOKEN_HANDLER(
             refresh_token_model=RefreshToken,
             token=token,
             context=context)

--- a/graphql_jwt/refresh_token/shortcuts.py
+++ b/graphql_jwt/refresh_token/shortcuts.py
@@ -1,19 +1,18 @@
-from django.apps import apps
 from django.utils.translation import ugettext as _
 
 from ..exceptions import JSONWebTokenError
-from ..settings import jwt_settings
+from .utils import get_refresh_token_by_model, get_refresh_token_model
 
 
-def get_refresh_token_model():
-    return apps.get_model(jwt_settings.JWT_REFRESH_TOKEN_MODEL)
-
-
-def get_refresh_token(token):
+def get_refresh_token(token, context=None):
     RefreshToken = get_refresh_token_model()
 
     try:
-        return RefreshToken.objects.get(token=token, revoked__isnull=True)
+        return get_refresh_token_by_model(
+            refresh_token_model=RefreshToken,
+            token=token,
+            context=context)
+
     except RefreshToken.DoesNotExist:
         raise JSONWebTokenError(_('Invalid refresh token'))
 

--- a/graphql_jwt/refresh_token/utils.py
+++ b/graphql_jwt/refresh_token/utils.py
@@ -1,0 +1,11 @@
+from django.apps import apps
+
+from ..settings import jwt_settings
+
+
+def get_refresh_token_model():
+    return apps.get_model(jwt_settings.JWT_REFRESH_TOKEN_MODEL)
+
+
+def get_refresh_token_by_model(refresh_token_model, token, context=None):
+    return refresh_token_model.objects.get(token=token, revoked__isnull=True)

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -31,6 +31,8 @@ DEFAULTS = {
         lambda payload: payload.get(get_user_model().USERNAME_FIELD)
     ),
     'JWT_REFRESH_EXPIRED_HANDLER': 'graphql_jwt.utils.refresh_has_expired',
+    'JWT_GET_REFRESH_TOKEN_HANDLER':
+    'graphql_jwt.refresh_token.utils.get_refresh_token_by_model',
     'JWT_ALLOW_ANY_HANDLER': 'graphql_jwt.middleware.allow_any',
     'JWT_ALLOW_ANY_CLASSES': (),
 }
@@ -41,6 +43,7 @@ IMPORT_STRINGS = (
     'JWT_PAYLOAD_HANDLER',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER',
     'JWT_REFRESH_EXPIRED_HANDLER',
+    'JWT_GET_REFRESH_TOKEN_HANDLER',
     'JWT_ALLOW_ANY_HANDLER',
     'JWT_ALLOW_ANY_CLASSES',
 )

--- a/tests/refresh_token/test_admin.py
+++ b/tests/refresh_token/test_admin.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import site
 
 from graphql_jwt.refresh_token import admin
-from graphql_jwt.refresh_token.shortcuts import get_refresh_token_model
+from graphql_jwt.refresh_token.utils import get_refresh_token_model
 from graphql_jwt.shortcuts import create_refresh_token
 
 from ..decorators import skipif_django_version

--- a/tests/refresh_token/test_models.py
+++ b/tests/refresh_token/test_models.py
@@ -18,10 +18,21 @@ class AbstractRefreshTokenTests(UserTestCase):
 
     def test_generate_token(self):
         token = self.refresh_token.generate_token()
+        n_bytes = jwt_settings.JWT_REFRESH_TOKEN_N_BYTES
 
-        self.assertEqual(
-            len(token),
-            jwt_settings.JWT_REFRESH_TOKEN_N_BYTES * 2)
+        self.assertEqual(len(token), n_bytes * 2)
+
+    def test_get_token(self):
+        self.refresh_token.token = 'hashed'
+        token = self.refresh_token.get_token()
+
+        self.assertEqual(self.refresh_token._cached_token, token)
+        self.assertNotEqual(self.refresh_token.token, token)
+
+        del self.refresh_token._cached_token
+        token = self.refresh_token.get_token()
+
+        self.assertEqual(self.refresh_token.token, token)
 
     def test_is_expired(self):
         with refresh_expired():


### PR DESCRIPTION
Hash refresh tokens before save:

```py
import hashlib

from django.db.models.signals import pre_save
from django.dispatch import receiver

from graphql_jwt.settings import jwt_settings


@receiver(pre_save, sender=jwt_settings.JWT_REFRESH_TOKEN_MODEL)
def hash_refresh_token(sender, instance, **kwargs):
    if not instance.pk:
        instance.token = hashlib.sha512(instance.token.encode()).hexdigest()
```

Hash refresh tokens before get instances:

```py
import hashlib

from graphql_jwt.refresh_token.utils import get_refresh_token_by_model


def get_refresh_token(refresh_token_model, token, context=None):
    token = hashlib.sha512(token.encode()).hexdigest()
    return get_refresh_token_by_model(refresh_token_model, token, context)
```

Configure JWT settings:

```py
GRAPHQL_JWT = {
    'JWT_VERIFY_EXPIRATION': True,
    'JWT_LONG_RUNNING_REFRESH_TOKEN': True,
    'JWT_GET_REFRESH_TOKEN_HANDLER': 'mysite.get_refresh_token',
}
```

Edit:  renamed handler function