### PR TITLE
Add: pass '**kwargs'  for JSONWebTokenMutation resolver

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -15,7 +15,7 @@ If you want to customize the ``ObtainJSONWebToken`` behavior, you'll need to cus
         user = graphene.Field(UserType)
 
         @classmethod
-        def resolve(cls, root, info):
+        def resolve(cls, root, info, **kwargs):
             return cls(user=info.context.user)
 
 Authenticate the user and obtain a **JSON Web Token** and the *user id*::

--- a/graphql_jwt/mixins.py
+++ b/graphql_jwt/mixins.py
@@ -39,7 +39,7 @@ class VerifyMixin(object):
 class ResolveMixin(object):
 
     @classmethod
-    def resolve(cls, root, info):
+    def resolve(cls, root, info, **kwargs):
         return cls()
 
 

--- a/graphql_jwt/mutations.py
+++ b/graphql_jwt/mutations.py
@@ -33,7 +33,7 @@ class JSONWebTokenMutation(mixins.ObtainJSONWebTokenMixin,
     @classmethod
     @token_auth
     def mutate(cls, root, info, **kwargs):
-        return cls.resolve(root, info)
+        return cls.resolve(root, info, **kwargs)
 
 
 class ObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):

--- a/graphql_jwt/relay.py
+++ b/graphql_jwt/relay.py
@@ -34,7 +34,7 @@ class JSONWebTokenMutation(mixins.ObtainJSONWebTokenMixin,
     @classmethod
     @token_auth
     def mutate_and_get_payload(cls, root, info, **kwargs):
-        return cls.resolve(root, info)
+        return cls.resolve(root, info, **kwargs)
 
 
 class ObtainJSONWebToken(mixins.ResolveMixin, JSONWebTokenMutation):


### PR DESCRIPTION
This change will enable the developer to easily use the custom arguments passed to the mutation inherited by JSONWebTokenMutation.
eg: 
```
class Login(graphql_jwt.JSONWebTokenMutation):
    user = graphene.Field(UserType)

    class Arguments:
        username = graphene.String()
        password = graphene.String()
        some_token = graphene.String()    # some extra token to update

    @classmethod
    def resolve(cls, root, info, **kwargs):
        print (kwargs.get('some_token'))    # use some_token to update in resolver
        return cls(user=info.context.user)
```