### PR TITLE
JWT Cookie Authentication

### DIFF
--- a/docs/cookie_authentication.rst
+++ b/docs/cookie_authentication.rst
@@ -1,0 +1,13 @@
+Cookie authentication
+=====================
+
+When a token is requested and ``jwt_cookie`` decorator is set, the response will set the given cookie with the token string::
+
+    from django.urls import path
+
+    from graphql_extensions.views import GraphQLView
+    from graphql_jwt.decoratos import jwt_cookie
+
+    urlpatterns = [
+        path('graphql/', jwt_cookie(GraphQLView.as_view())),
+    ]

--- a/docs/cookie_authentication.rst
+++ b/docs/cookie_authentication.rst
@@ -5,8 +5,8 @@ When a token is requested and ``jwt_cookie`` decorator is set, the response will
 
     from django.urls import path
 
-    from graphql_extensions.views import GraphQLView
-    from graphql_jwt.decoratos import jwt_cookie
+    from graphene_django.views import GraphQLView
+    from graphql_jwt.decorators import jwt_cookie
 
     urlpatterns = [
         path('graphql/', jwt_cookie(GraphQLView.as_view())),

--- a/docs/cookie_authentication.rst
+++ b/docs/cookie_authentication.rst
@@ -11,3 +11,6 @@ When a token is requested and ``jwt_cookie`` decorator is set, the response will
     urlpatterns = [
         path('graphql/', jwt_cookie(GraphQLView.as_view())),
     ]
+
+
+If the ``jwt_cookie`` decorator is set, consider adding `CSRF middleware <https://docs.djangoproject.com/es/2.1/ref/csrf/>`_ ``'django.middleware.csrf.CsrfViewMiddleware'`` to provide protection against `Cross Site Request Forgeries <https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Django GraphQL JWT
    refresh_token
    customizing
    relay
+   cookie_authentication
    tests
    settings
    changelog

--- a/docs/relay.rst
+++ b/docs/relay.rst
@@ -4,7 +4,8 @@ Relay
 Complete support for `Relay <https://facebook.github.io/relay/>`_.
 
 Schema
--------
+------
+
 Add mutations to the root schema::
 
     import graphene

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -241,6 +241,14 @@ JWT_COOKIE_NAME
   Default: ``'JWT'``
 
 
+JWT_COOKIE_SECURE
+~~~~~~~~~~~~~~~~~
+
+  Whether to use a secure cookie for the JWT cookie. If this is set to True, the cookie will be marked as "secure", which means browsers may ensure that the cookie is only sent under an HTTPS connection.
+
+  Default: ``False``
+
+
 .. _JWT_ALGORITHM: https://pyjwt.readthedocs.io/en/latest/algorithms.html
 .. _JWT_AUDIENCE: http://pyjwt.readthedocs.io/en/latest/usage.html#audience-claim-aud
 .. _JWT_ISSUER: http://pyjwt.readthedocs.io/en/latest/usage.html#issuer-claim-iss

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -233,10 +233,10 @@ JWT_ARGUMENT_NAME
 Cookie authentication
 ---------------------
 
-JWT_COOKIE_KEY
-~~~~~~~~~~~~~~
+JWT_COOKIE_NAME
+~~~~~~~~~~~~~~~
 
-  Cookie key when HTTP cookies are used as a valid transport for the token
+  The name of the cookie when HTTP cookies are used as a valid transport for the token
 
   Default: ``'JWT'``
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -230,6 +230,17 @@ JWT_ARGUMENT_NAME
   Default: ``'token'``
 
 
+Cookie authentication
+---------------------
+
+JWT_COOKIE_KEY
+~~~~~~~~~~~~~~
+
+  Cookie key when HTTP cookies are used as a valid transport for the token
+
+  Default: ``'JWT'``
+
+
 .. _JWT_ALGORITHM: https://pyjwt.readthedocs.io/en/latest/algorithms.html
 .. _JWT_AUDIENCE: http://pyjwt.readthedocs.io/en/latest/usage.html#audience-claim-aud
 .. _JWT_ISSUER: http://pyjwt.readthedocs.io/en/latest/usage.html#issuer-claim-iss

--- a/graphql_jwt/backends.py
+++ b/graphql_jwt/backends.py
@@ -4,8 +4,8 @@ from .utils import get_credentials, get_user_by_natural_key
 
 class JSONWebTokenBackend(object):
 
-    def authenticate(self, request=None, **kwargs):
-        if request is None:
+    def authenticate(self, request=None, skip_jwt_backend=False, **kwargs):
+        if request is None or skip_jwt_backend:
             return None
 
         token = get_credentials(request, **kwargs)

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -121,7 +121,7 @@ def jwt_cookie(view_func):
             expiration = datetime.utcnow() + jwt_settings.JWT_EXPIRATION_DELTA
 
             response.set_cookie(
-                jwt_settings.JWT_COOKIE_KEY,
+                jwt_settings.JWT_COOKIE_NAME,
                 request.jwt,
                 expires=expiration,
                 httponly=True)

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -124,7 +124,8 @@ def jwt_cookie(view_func):
                 jwt_settings.JWT_COOKIE_NAME,
                 request.jwt,
                 expires=expiration,
-                httponly=True)
+                httponly=True,
+                secure=jwt_settings.JWT_COOKIE_SECURE)
 
         return response
     return wrapped_view

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -12,7 +12,6 @@ from . import exceptions
 from .refresh_token.shortcuts import refresh_token_lazy
 from .settings import jwt_settings
 from .shortcuts import get_token
-from .utils import get_authorization_header
 
 __all__ = [
     'user_passes_test',
@@ -73,18 +72,16 @@ def token_auth(f):
 
             if jwt_settings.JWT_LONG_RUNNING_REFRESH_TOKEN:
                 payload.refresh_token = refresh_token_lazy(user)
-  
+
             return payload
 
         username = kwargs.get(get_user_model().USERNAME_FIELD)
 
-        if get_authorization_header(info.context) is not None:
-            del info.context.META[jwt_settings.JWT_AUTH_HEADER_NAME]
-
         user = authenticate(
             request=info.context,
             username=username,
-            password=password)
+            password=password,
+            skip_jwt_backend=True)
 
         if user is None:
             raise exceptions.JSONWebTokenError(

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -19,6 +19,7 @@ __all__ = [
     'staff_member_required',
     'permission_required',
     'token_auth',
+    'setup_jwt_cookie',
     'jwt_cookie',
 ]
 

--- a/graphql_jwt/mixins.py
+++ b/graphql_jwt/mixins.py
@@ -4,6 +4,7 @@ import graphene
 from graphene.types.generic import GenericScalar
 
 from . import exceptions
+from .decorators import setup_jwt_cookie
 from .refresh_token.mixins import RefreshTokenMixin
 from .settings import jwt_settings
 from .utils import get_payload, get_user_by_payload
@@ -49,6 +50,7 @@ class KeepAliveRefreshMixin(object):
         token = graphene.String(required=True)
 
     @classmethod
+    @setup_jwt_cookie
     def refresh(cls, root, info, token, **kwargs):
         context = info.context
         payload = get_payload(token, context)

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext as _
 import graphene
 
 from .. import exceptions
+from ..decorators import setup_jwt_cookie
 from ..settings import jwt_settings
 from .shortcuts import get_refresh_token
 
@@ -15,6 +16,7 @@ class RefreshTokenMixin(object):
         refresh_token = graphene.String(required=True)
 
     @classmethod
+    @setup_jwt_cookie
     def refresh(cls, root, info, refresh_token, **kwargs):
         context = info.context
         refresh_token = get_refresh_token(refresh_token, info.context)

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -36,6 +36,7 @@ DEFAULTS = {
     'JWT_ALLOW_ANY_HANDLER': 'graphql_jwt.middleware.allow_any',
     'JWT_ALLOW_ANY_CLASSES': (),
     'JWT_COOKIE_NAME': 'JWT',
+    'JWT_COOKIE_SECURE': False,
 }
 
 IMPORT_STRINGS = (

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -35,6 +35,7 @@ DEFAULTS = {
     'graphql_jwt.refresh_token.utils.get_refresh_token_by_model',
     'JWT_ALLOW_ANY_HANDLER': 'graphql_jwt.middleware.allow_any',
     'JWT_ALLOW_ANY_CLASSES': (),
+    'JWT_COOKIE_KEY': 'JWT',
 }
 
 IMPORT_STRINGS = (

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -35,7 +35,7 @@ DEFAULTS = {
     'graphql_jwt.refresh_token.utils.get_refresh_token_by_model',
     'JWT_ALLOW_ANY_HANDLER': 'graphql_jwt.middleware.allow_any',
     'JWT_ALLOW_ANY_CLASSES': (),
-    'JWT_COOKIE_KEY': 'JWT',
+    'JWT_COOKIE_NAME': 'JWT',
 }
 
 IMPORT_STRINGS = (

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -60,7 +60,7 @@ def get_http_authorization(request):
     prefix = jwt_settings.JWT_AUTH_HEADER_PREFIX
 
     if len(auth) != 2 or auth[0].lower() != prefix.lower():
-        return request.COOKIES.get(jwt_settings.JWT_COOKIE_KEY)
+        return request.COOKIES.get(jwt_settings.JWT_COOKIE_NAME)
     return auth[1]
 
 

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -55,12 +55,12 @@ def jwt_decode(token, context=None):
         algorithms=[jwt_settings.JWT_ALGORITHM])
 
 
-def get_authorization_header(request):
+def get_http_authorization(request):
     auth = request.META.get(jwt_settings.JWT_AUTH_HEADER_NAME, '').split()
     prefix = jwt_settings.JWT_AUTH_HEADER_PREFIX
 
     if len(auth) != 2 or auth[0].lower() != prefix.lower():
-        return None
+        return request.COOKIES.get(jwt_settings.JWT_COOKIE_KEY)
     return auth[1]
 
 
@@ -77,7 +77,7 @@ def get_token_argument(request, **kwargs):
 
 def get_credentials(request, **kwargs):
     return (get_token_argument(request, **kwargs) or
-            get_authorization_header(request))
+            get_http_authorization(request))
 
 
 def get_payload(token, context=None):

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -15,9 +15,7 @@ class TokenAuthMixin(object):
 
         payload = get_payload(response.data['tokenAuth']['token'])
 
-        self.assertEqual(
-            self.user.get_username(),
-            payload[self.user.USERNAME_FIELD])
+        self.assertUsernameIn(payload)
 
     def test_token_auth_invalid_credentials(self):
         response = self.execute({
@@ -37,9 +35,7 @@ class VerifyMixin(object):
 
         payload = response.data['verifyToken']['payload']
 
-        self.assertEqual(
-            self.user.get_username(),
-            payload[self.user.USERNAME_FIELD])
+        self.assertUsernameIn(payload)
 
     def test_verify_invalid_token(self):
         response = self.execute({
@@ -59,15 +55,10 @@ class RefreshMixin(object):
 
         data = response.data['refreshToken']
         token = data['token']
-
-        self.assertNotEqual(token, self.token)
-
-        self.assertEqual(
-            data['payload'][self.user.USERNAME_FIELD],
-            self.user.get_username())
-
         payload = get_payload(token)
 
+        self.assertNotEqual(token, self.token)
+        self.assertUsernameIn(data['payload'])
         self.assertEqual(payload['origIat'], self.payload['origIat'])
         self.assertGreater(payload['exp'], self.payload['exp'])
 

--- a/tests/refresh_token/mixins.py
+++ b/tests/refresh_token/mixins.py
@@ -32,10 +32,7 @@ class TokenAuthMixin(RefreshTokenMutationMixin):
         payload = get_payload(data['token'])
         refresh_token = get_refresh_token(data['refreshToken'])
 
-        self.assertEqual(
-            self.user.get_username(),
-            payload[self.user.USERNAME_FIELD])
-
+        self.assertUsernameIn(payload)
         self.assertEqual(refresh_token.user, self.user)
 
 
@@ -59,6 +56,7 @@ class RefreshMixin(RefreshTokenMutationMixin, RefreshTokenMixin):
         refresh_token = get_refresh_token(data['refreshToken'])
         payload = get_payload(token)
 
+        self.assertUsernameIn(payload)
         self.assertNotEqual(token, self.token)
         self.assertGreater(payload['exp'], self.payload['exp'])
 

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -27,10 +27,7 @@ class TokenAuthTests(CookieGraphQLViewTestCase):
         payload = get_payload(token)
 
         self.assertEqual(token, response.data['tokenAuth']['token'])
-
-        self.assertEqual(
-            self.user.get_username(),
-            payload[self.user.USERNAME_FIELD])
+        self.assertUsernameIn(payload)
 
 
 class ViewerTests(CookieGraphQLViewTestCase):

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -24,7 +24,7 @@ class TokenAuthTests(CookieGraphQLViewTestCase):
             'password': 'dolphins',
         })
 
-        token = response.cookies.get(jwt_settings.JWT_COOKIE_KEY).value
+        token = response.cookies.get(jwt_settings.JWT_COOKIE_NAME).value
         payload = get_payload(token)
 
         self.assertEqual(token, response.data['tokenAuth']['token'])

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,6 +1,7 @@
 import graphene
 
 import graphql_jwt
+from graphql_jwt.settings import jwt_settings
 from graphql_jwt.utils import get_payload
 
 from .testcases import CookieGraphQLViewTestCase
@@ -23,7 +24,7 @@ class TokenAuthTests(CookieGraphQLViewTestCase):
             'password': 'dolphins',
         })
 
-        token = response.cookies.get('JWT').value
+        token = response.cookies.get(jwt_settings.JWT_COOKIE_KEY).value
         payload = get_payload(token)
 
         self.assertEqual(token, response.data['tokenAuth']['token'])

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -1,0 +1,52 @@
+import graphene
+
+import graphql_jwt
+from graphql_jwt.utils import get_payload
+
+from .testcases import CookieGraphQLViewTestCase
+
+
+class TokenAuthTests(CookieGraphQLViewTestCase):
+    query = '''
+    mutation TokenAuth($username: String!, $password: String!) {
+      tokenAuth(username: $username, password: $password) {
+        token
+      }
+    }'''
+
+    class Mutation(graphene.ObjectType):
+        token_auth = graphql_jwt.ObtainJSONWebToken.Field()
+
+    def test_token_auth(self):
+        response = self.execute({
+            self.user.USERNAME_FIELD: self.user.get_username(),
+            'password': 'dolphins',
+        })
+
+        token = response.cookies.get('JWT').value
+        payload = get_payload(token)
+
+        self.assertEqual(token, response.data['tokenAuth']['token'])
+
+        self.assertEqual(
+            self.user.get_username(),
+            payload[self.user.USERNAME_FIELD])
+
+
+class ViewerTests(CookieGraphQLViewTestCase):
+    query = '''
+    {
+      viewer
+    }'''
+
+    class Query(graphene.ObjectType):
+        viewer = graphene.String()
+
+        def resolve_viewer(self, info):
+            return info.context.user.username
+
+    def test_viewer(self):
+        self.authenticate()
+        response = self.execute()
+
+        self.assertEqual(self.user.get_username(), response.data['viewer'])

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -40,7 +40,7 @@ class ViewerTests(CookieGraphQLViewTestCase):
         viewer = graphene.String()
 
         def resolve_viewer(self, info):
-            return info.context.user.username
+            return info.context.user.get_username()
 
     def test_viewer(self):
         self.authenticate()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import AnonymousUser, Permission
 from promise import Promise, is_thenable
 
 from graphql_jwt import decorators, exceptions
-from graphql_jwt.settings import jwt_settings
 
 from .testcases import TestCase
 
@@ -122,19 +121,13 @@ class PermissionRequiredTests(TestCase):
 
 class TokenAuthTests(TestCase):
 
-    def test_already_authenticated(self):
+    def test_is_thenable(self):
 
         @decorators.token_auth
         def wrapped(cls, root, info, **kwargs):
             return Promise()
 
-        headers = {
-            jwt_settings.JWT_AUTH_HEADER_NAME: '{0} {1}'.format(
-                jwt_settings.JWT_AUTH_HEADER_PREFIX,
-                self.token),
-        }
-
-        info_mock = self.info(AnonymousUser(), **headers)
+        info_mock = self.info(AnonymousUser())
 
         result = wrapped(
             self,
@@ -143,8 +136,4 @@ class TokenAuthTests(TestCase):
             password='dolphins',
             username=self.user.get_username())
 
-        self.assertIsNotNone(is_thenable(result))
-
-        self.assertNotIn(
-            jwt_settings.JWT_AUTH_HEADER_NAME,
-            info_mock.context.META)
+        self.assertTrue(is_thenable(result))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,7 @@ class GetHTTPAuthorizationHeaderTests(TestCase):
         }
 
         request = self.request_factory.get('/', **headers)
-        request.COOKIES[jwt_settings.JWT_COOKIE_KEY] = self.token
+        request.COOKIES[jwt_settings.JWT_COOKIE_NAME] = self.token
         authorization_cookie = utils.get_http_authorization(request)
 
         self.assertEqual(authorization_cookie, self.token)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,9 +29,9 @@ class JWTPayloadTests(TestCase):
         self.assertEqual(payload['iss'], 'test')
 
 
-class GetAuthorizationHeaderTests(TestCase):
+class GetHTTPAuthorizationHeaderTests(TestCase):
 
-    def test_get_header(self):
+    def test_get_authorization_header(self):
         headers = {
             jwt_settings.JWT_AUTH_HEADER_NAME: '{} {}'.format(
                 jwt_settings.JWT_AUTH_HEADER_PREFIX,
@@ -39,7 +39,7 @@ class GetAuthorizationHeaderTests(TestCase):
         }
 
         request = self.request_factory.get('/', **headers)
-        authorization_header = utils.get_authorization_header(request)
+        authorization_header = utils.get_http_authorization(request)
 
         self.assertEqual(authorization_header, self.token)
 
@@ -49,9 +49,22 @@ class GetAuthorizationHeaderTests(TestCase):
         }
 
         request = self.request_factory.get('/', **headers)
-        authorization_header = utils.get_authorization_header(request)
+        authorization_header = utils.get_http_authorization(request)
 
         self.assertIsNone(authorization_header)
+
+    def test_get_authorization_cookie(self):
+        headers = {
+            jwt_settings.JWT_AUTH_HEADER_NAME: '{} {}'.format(
+                jwt_settings.JWT_AUTH_HEADER_PREFIX,
+                self.token),
+        }
+
+        request = self.request_factory.get('/', **headers)
+        request.COOKIES[jwt_settings.JWT_COOKIE_KEY] = self.token
+        authorization_cookie = utils.get_http_authorization(request)
+
+        self.assertEqual(authorization_cookie, self.token)
 
 
 class GetCredentialsTests(TestCase):

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -52,6 +52,10 @@ class SchemaTestCase(TestCase, JSONWebTokenTestCase):
         assert self.query, ('`query` property not specified')
         return self.client.execute(self.query, variables)
 
+    def assertUsernameIn(self, payload):
+        username = payload[self.user.USERNAME_FIELD]
+        self.assertEqual(self.user.get_username(), username)
+
 
 class RelaySchemaTestCase(SchemaTestCase):
 

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, testcases
 
@@ -59,9 +61,10 @@ class RelaySchemaTestCase(SchemaTestCase):
 
 class CookieGraphQLViewClient(JSONWebTokenClient):
 
-    def post(self, path, **kwargs):
+    def post(self, path, data, **kwargs):
+        data = json.dumps(data)
         kwargs.setdefault('content_type', 'application/json')
-        return super(CookieGraphQLViewClient, self).post(path, **kwargs)
+        return self.generic('POST', path, data, **kwargs)
 
     def authenticate(self, token):
         self.cookies[jwt_settings.JWT_COOKIE_KEY] = token

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -66,9 +66,8 @@ class RelaySchemaTestCase(SchemaTestCase):
 class CookieGraphQLViewClient(JSONWebTokenClient):
 
     def post(self, path, data, **kwargs):
-        data = json.dumps(data)
         kwargs.setdefault('content_type', 'application/json')
-        return self.generic('POST', path, data, **kwargs)
+        return self.generic('POST', path, json.dumps(data), **kwargs)
 
     def authenticate(self, token):
         self.cookies[jwt_settings.JWT_COOKIE_KEY] = token

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -6,7 +6,7 @@ from graphql.execution.base import ResolveInfo
 
 from graphql_jwt.decorators import jwt_cookie
 from graphql_jwt.settings import jwt_settings
-from graphql_jwt.testcases import JSONWebTokenTestCase, JSONWebTokenClient
+from graphql_jwt.testcases import JSONWebTokenClient, JSONWebTokenTestCase
 from graphql_jwt.utils import jwt_encode, jwt_payload
 
 from .compat import mock

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -70,7 +70,7 @@ class CookieGraphQLViewClient(JSONWebTokenClient):
         return self.generic('POST', path, json.dumps(data), **kwargs)
 
     def authenticate(self, token):
-        self.cookies[jwt_settings.JWT_COOKIE_KEY] = token
+        self.cookies[jwt_settings.JWT_COOKIE_NAME] = token
 
     def execute(self, query, variables=None, **extra):
         data = {


### PR DESCRIPTION
Resolve #55

When a token is requested and `jwt_cookie` decorator is set, the response will set the given cookie with the token string:

```py
from django.urls import path

from graphene_django.views import GraphQLView
from graphql_jwt.decoratos import jwt_cookie

urlpatterns = [
    path('graphql/', jwt_cookie(GraphQLView.as_view())),
]
```

Update: Used `graphene_django.views` instead of `graphql_extensions.views`.