### PR TITLE
Allow users to pass in custom exceptions.

### DIFF
--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -33,14 +33,14 @@ def context(f):
     return decorator
 
 
-def user_passes_test(test_func):
+def user_passes_test(test_func, exc=exceptions.PermissionDenied()):
     def decorator(f):
         @wraps(f)
         @context(f)
         def wrapper(context, *args, **kwargs):
             if test_func(context.user):
                 return f(*args, **kwargs)
-            raise exceptions.PermissionDenied()
+            raise exc
         return wrapper
     return decorator
 


### PR DESCRIPTION
Updates `user_passes_test` to accept a custom exception.

My main reasoning for this is so that I can pass in specific exceptions for each type of user. E.g.:

```
login_required = user_passes_test(lambda u: u.is_authenticated, Unauthenticated('You are not logged in.'))
special_permission = user_passes_test(lambda u: u.is_authenticated, UserNotSpecial('You are not special enough to do this.'))
```

Under the hood, each of my exceptions has a `status_code` field and I'm using the [extensions field](https://facebook.github.io/graphql/draft/#example-fce18) on an error response to put that particular status code (e.g. 401, 403, 405, 409, etc) in the error response.