### PR TITLE
Get user by natural key handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
 * Fixed @context decorator to determine the info argument
 * Added _cached_token to refresh token instances to allow hashed tokens
 * Added JWT_GET_REFRESH_TOKEN_HANDLER setting variable
-* Improved argument authentication using mulitple credentials
+* Improved argument authentication using multiple credentials
 * Added execute method to SchemaTestCase
 * Added graphql_jwt classes to JWT_ALLOW_ANY_CLASSES
 * Added @superuser_required decorator

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -95,6 +95,14 @@ JWT_PAYLOAD_GET_USERNAME_HANDLER
     lambda payload: payload.get(get_user_model().USERNAME_FIELD)
 
 
+JWT_GET_USER_BY_NATURAL_KEY_HANDLER
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  A custom function to get User object from username
+
+  .. autofunction:: graphql_jwt.utils.get_user_by_natural_key
+
+
 Token expiration
 ----------------
 

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -30,6 +30,8 @@ DEFAULTS = {
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': (
         lambda payload: payload.get(get_user_model().USERNAME_FIELD)
     ),
+    'JWT_GET_USER_BY_NATURAL_KEY_HANDLER':
+    'graphql_jwt.utils.get_user_by_natural_key',
     'JWT_REFRESH_EXPIRED_HANDLER': 'graphql_jwt.utils.refresh_has_expired',
     'JWT_GET_REFRESH_TOKEN_HANDLER':
     'graphql_jwt.refresh_token.utils.get_refresh_token_by_model',
@@ -44,6 +46,7 @@ IMPORT_STRINGS = (
     'JWT_DECODE_HANDLER',
     'JWT_PAYLOAD_HANDLER',
     'JWT_PAYLOAD_GET_USERNAME_HANDLER',
+    'JWT_GET_USER_BY_NATURAL_KEY_HANDLER',
     'JWT_REFRESH_EXPIRED_HANDLER',
     'JWT_GET_REFRESH_TOKEN_HANDLER',
     'JWT_ALLOW_ANY_HANDLER',

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -92,10 +92,10 @@ def get_payload(token, context=None):
     return payload
 
 
-def get_user_by_natural_key(user_id):
+def get_user_by_natural_key(username):
     User = get_user_model()
     try:
-        return User.objects.get_by_natural_key(user_id)
+        return User.objects.get_by_natural_key(username)
     except User.DoesNotExist:
         return None
 
@@ -106,7 +106,7 @@ def get_user_by_payload(payload):
     if not username:
         raise exceptions.JSONWebTokenError(_('Invalid payload'))
 
-    user = get_user_by_natural_key(username)
+    user = jwt_settings.JWT_GET_USER_BY_NATURAL_KEY_HANDLER(username)
 
     if user is not None and not user.is_active:
         raise exceptions.JSONWebTokenError(_('User is disabled'))


### PR DESCRIPTION
Allows to customize the obtaining of a User object for JWT authentication.

```py
from django.contrib.auth import get_user_model
from django.db.models import Q


def custom_get_user_by_natural_key(username):
    User = get_user_model()
    try:
        return User.objects.get(
            Q(username=username) | Q(email=username) | Q(phone=username)
        )
    except User.DoesNotExist:
        return None


GRAPHQL_JWT = {
    'JWT_GET_USER_BY_NATURAL_KEY_HANDLER': custom_get_user_by_natural_key
}
```

ref #84