### PR TITLE
Changed warning to be logged by checking instances.

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,3 +22,5 @@ AUTHENTICATION_BACKENDS = [
 GRAPHENE = {
     'MIDDLEWARE': ['graphql_jwt.middleware.JSONWebTokenMiddleware'],
 }
+
+MIDDLEWARE = []

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,7 @@
 import json
 import warnings
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
 
@@ -28,8 +29,16 @@ class DjangoMiddlewareTests(TestCase):
 
         with warnings.catch_warnings(record=True) as warning_list:
             JSONWebTokenMiddleware()
+            self.assertFalse(warning_list)
+
+        settings.MIDDLEWARE += [
+            'graphql_jwt.middleware.JSONWebTokenMiddleware']
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            JSONWebTokenMiddleware()
             self.assertTrue(warning_list)
 
+        settings.MIDDLEWARE = settings.MIDDLEWARE[:-1]
         graphene_settings.MIDDLEWARE = [JSONWebTokenMiddleware]
 
     def test_authenticate(self):


### PR DESCRIPTION
Also added in a check for Django's middleware settings. This allows views
to have the middleware setting applied directly to it without triggering
the log. This is helpful for cases where there are multiple schemas using
different modes of authentication.

References #97 