### PR TITLE
Remove usage of deleted packages

### DIFF
--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from functools import wraps
 
 from django.contrib.auth import authenticate, get_user_model
-from django.utils import six
 from django.utils.translation import ugettext as _
 
 from graphql.execution.base import ResolveInfo
@@ -52,7 +51,7 @@ superuser_required = user_passes_test(lambda u: u.is_active and u.is_superuser)
 
 def permission_required(perm):
     def check_perms(user):
-        if isinstance(perm, six.string_types):
+        if isinstance(perm, str):
             perms = (perm,)
         else:
             perms = perm

--- a/graphql_jwt/path.py
+++ b/graphql_jwt/path.py
@@ -1,10 +1,8 @@
-from django.utils import six
-
 __all__ = ['PathDict']
 
 
 def filter_strings(items):
-    return tuple(item for item in items if isinstance(item, six.string_types))
+    return tuple(item for item in items if isinstance(item, str))
 
 
 class PathDict(dict):

--- a/graphql_jwt/refresh_token/models.py
+++ b/graphql_jwt/refresh_token/models.py
@@ -5,14 +5,12 @@ from calendar import timegm
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from ..settings import jwt_settings
 from . import managers, signals
 
 
-@python_2_unicode_compatible
 class AbstractRefreshToken(models.Model):
     id = models.BigAutoField(primary_key=True)
     user = models.ForeignKey(

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -4,7 +4,6 @@ from importlib import import_module
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test.signals import setting_changed
-from django.utils import six
 
 DEFAULTS = {
     'JWT_ALGORITHM': 'HS256',
@@ -56,7 +55,7 @@ IMPORT_STRINGS = (
 
 
 def perform_import(value, setting_name):
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         return import_from_string(value, setting_name)
     if isinstance(value, (list, tuple)):
         return [import_from_string(item, setting_name) for item in value]


### PR DESCRIPTION
Fixes #150 
- remove all usages of six
- drop python 2 compatibility

> Since we expect apps to drop Python 2 compatibility when adding support for Django 3.0, we’re removing these APIs at this time.

