### PR TITLE
limit to django <=2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     )),
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'Django>=1.11',
+        'Django >=1.11, <=2.2',
         'graphene-django>=2.0.0',
         'graphql-core>=2.1,<3',
         'PyJWT>=1.5.0',


### PR DESCRIPTION
Drops Django3.0 compatibility so that builds off master branch work.

Closed #150 
