### PR TITLE
Add tests for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,16 @@ matrix:
   include:
     - python: 3.7
       env: TOXENV=flake8
-    - python: 2.7
-      env: TOXENV=py27-django111
+
+    # Django 1.11
     - python: 3.4
       env: TOXENV=py34-django111
     - python: 3.5
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
+
+    # Django 2.0
     - python: 3.4
       env: TOXENV=py34-django20
     - python: 3.5
@@ -23,29 +25,43 @@ matrix:
       env: TOXENV=py36-django20
     - python: 3.7
       env: TOXENV=py37-django20
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-django20
+
+    # Django 2.1
     - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
     - python: 3.7
       env: TOXENV=py37-django21
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-django21
+
+    # Django 2.2
     - python: 3.5
       env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-django22
+
+    # Django 3.0
+    - python: 3.6
+      env: TOXENV=py36-django30
+    - python: 3.7
+      env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
+
+    # Django master
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
-    - python: 3.8-dev
+    - python: 3.8
       env: TOXENV=py38-djangomaster
   allow_failures:
     - env: TOXENV=py36-djangomaster

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -60,6 +59,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
     ],
     zip_safe=False,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 envlist =
   flake8
-  py{27,34,35,36}-django111,
+  py{34,35,36}-django111,
   py{34,35,36,37,38}-django20,
   py{35,36,37,38}-django21,
   py{35,36,37,38}-django22,
+  py{36,37,38}-django30,
   py{36,37,38}-djangomaster,
 
 [testenv]
 whitelist_externals = make
 basepython =
-  py27: python2.7
   py34: python3.4
   py35: python3.5
   py36: python3.6
@@ -23,12 +23,12 @@ setenv =
   PYTHONWARNINGS=once
 
 deps =
-  py27: mock
   -rrequirements/test.txt
   django111: Django~=1.11
   django20: Django~=2.0
   django21: Django~=2.1
-  django22: Django~=2.2a1
+  django22: Django~=2.2
+  django30: Django~=3.0
   djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 commands = make coverage


### PR DESCRIPTION
Accompanies https://github.com/flavors/django-graphql-jwt/pull/151

Travis should test Django 3.0, and stop testing Python 2.7.