### PR TITLE
Update Customizing documentation for relay.

### DIFF
--- a/docs/relay.rst
+++ b/docs/relay.rst
@@ -109,7 +109,7 @@ If you want to customize the ``ObtainJSONWebToken`` behavior, you'll need to cus
         user = graphene.Field(UserType)
 
         @classmethod
-        def resolve(cls, root, info):
+        def resolve(cls, root, info, **kwargs):
             return cls(user=info.context.user)
 
 Authenticate the user and obtain a **JSON Web Token** and the *user id*::


### PR DESCRIPTION
I just tried to follow the docs for customizing relay ObtainJSONWebToken. I couldn't get it to work without adding kwargs as as an argument for the resolve method override. Easy to work out, but unless I'm doing something wrong should this be added to the docs?