### PR TITLE
Replace deprecated ugettext with gettext for python 3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ Contributors
 * Aaron Boman `@frenchtoast747 <https://github.com/frenchtoast747>`_
 * Colton Hicks `@coltonbh <https://github.com/coltonbh>`_
 * Lasse Steffen `@lassesteffen <https://github.com/lassesteffen>`_
+* Patryk Bratkowski `@patryk-tech <https://github.com/patryk-tech/>`_

--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,17 @@ Add *django-graphql-jwt* mutations to the root schema:
     schema = graphene.Schema(mutation=Mutation)
 
 
+Run Tests in Docker
+-------------------
+
+You can run ``tox`` by using ``docker-compose``:
+
+::
+
+    docker-compose -f docker-compose.tox.yml up
+
+Alternatively, you may edit the ``docker-compose.tox.yml`` file and limit the test to a single environment.
+
 Documentation
 -------------
 

--- a/docker-compose.tox.yml
+++ b/docker-compose.tox.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  tox:
+    image: themattrix/tox-base
+    entrypoint:
+      - tox
+      # uncomment the following lines (and optionally replace 'py38' with a different environment)
+      # to limit tests to specific environments
+      # - "-e"
+      # - py38
+    volumes:
+      - "./:/app"
+    working_dir: /app

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from functools import wraps
 
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from graphql.execution.base import ResolveInfo
 from promise import Promise, is_thenable

--- a/graphql_jwt/exceptions.py
+++ b/graphql_jwt/exceptions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class JSONWebTokenError(Exception):

--- a/graphql_jwt/mixins.py
+++ b/graphql_jwt/mixins.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import graphene
 from graphene.types.generic import GenericScalar

--- a/graphql_jwt/refresh_token/admin/__init__.py
+++ b/graphql_jwt/refresh_token/admin/__init__.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .. import models
 from . import filters

--- a/graphql_jwt/refresh_token/admin/filters.py
+++ b/graphql_jwt/refresh_token/admin/filters.py
@@ -1,5 +1,5 @@
 from django.contrib.admin import SimpleListFilter
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'ExpiredFilter',

--- a/graphql_jwt/refresh_token/apps.py
+++ b/graphql_jwt/refresh_token/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class RefreshTokenConfig(AppConfig):

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import graphene
 

--- a/graphql_jwt/refresh_token/models.py
+++ b/graphql_jwt/refresh_token/models.py
@@ -5,7 +5,7 @@ from calendar import timegm
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..settings import jwt_settings
 from . import managers, signals

--- a/graphql_jwt/refresh_token/shortcuts.py
+++ b/graphql_jwt/refresh_token/shortcuts.py
@@ -1,5 +1,5 @@
 from django.utils.functional import lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from ..exceptions import JSONWebTokenError
 from ..settings import jwt_settings

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -2,7 +2,7 @@ from calendar import timegm
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import jwt
 


### PR DESCRIPTION
Hello, this should be a safe commit that rids `tox` of deprecation warnings. As python2.7 is no longer supported by this package, we can replace the `ugettext` and `ugettext_lazy` imports with their non-unicode counterparts. The unicode versions are scheduled for deprecation in Django 4, but I personally see no reason to keep them (and this change makes tox happy).

Just ran a quick `for f in $(grep -lR ugettext); do sed -i 's/ugettext/gettext/g' "$f"; done`.

Regards,
Pat