### PR TITLE
Replace deprecated ugettext with gettext for python 3

### DIFF
--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from functools import wraps
 
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from graphql.execution.base import ResolveInfo
 from promise import Promise, is_thenable

--- a/graphql_jwt/exceptions.py
+++ b/graphql_jwt/exceptions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class JSONWebTokenError(Exception):

--- a/graphql_jwt/mixins.py
+++ b/graphql_jwt/mixins.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import graphene
 from graphene.types.generic import GenericScalar

--- a/graphql_jwt/refresh_token/admin/__init__.py
+++ b/graphql_jwt/refresh_token/admin/__init__.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .. import models
 from . import filters

--- a/graphql_jwt/refresh_token/admin/filters.py
+++ b/graphql_jwt/refresh_token/admin/filters.py
@@ -1,5 +1,5 @@
 from django.contrib.admin import SimpleListFilter
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 __all__ = [
     'ExpiredFilter',

--- a/graphql_jwt/refresh_token/apps.py
+++ b/graphql_jwt/refresh_token/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class RefreshTokenConfig(AppConfig):

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import graphene
 

--- a/graphql_jwt/refresh_token/models.py
+++ b/graphql_jwt/refresh_token/models.py
@@ -5,7 +5,7 @@ from calendar import timegm
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..settings import jwt_settings
 from . import managers, signals

--- a/graphql_jwt/refresh_token/shortcuts.py
+++ b/graphql_jwt/refresh_token/shortcuts.py
@@ -1,5 +1,5 @@
 from django.utils.functional import lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from ..exceptions import JSONWebTokenError
 from ..settings import jwt_settings

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -2,7 +2,7 @@ from calendar import timegm
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import jwt
 


### PR DESCRIPTION
Hello, this should be a safe commit that rids `tox` of deprecation warnings. As python2.7 is no longer supported by this package, we can replace the `ugettext` and `ugettext_lazy` imports with their non-unicode counterparts. The unicode versions are scheduled for deprecation in Django 4, but I personally see no reason to keep them (and this change makes tox happy).

Just ran a quick `for f in $(grep -lR ugettext); do sed -i 's/ugettext/gettext/g' "$f"; done`.

Regards,
Pat