### PR TITLE
Added asymmetric algorithms support

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -55,6 +55,22 @@ PyJWT
   Default: ``settings.SECRET_KEY``
 
 
+`JWT_PUBLIC_KEY`_
+~~~~~~~~~~~~~~~~~
+
+  The RSA public key for *RS256*, *RS384* or *RS512* asymmetric algorithms. ``JWT_SECRET_KEY`` setting will be ignored
+
+  Default: ``None``
+
+
+`JWT_PRIVATE_KEY`_
+~~~~~~~~~~~~~~~~~
+
+  The RSA private key for *RS256*, *RS384* or *RS512* asymmetric algorithms. ``JWT_SECRET_KEY`` setting will be ignored
+
+  Default: ``None``
+
+
 `JWT_VERIFY`_
 ~~~~~~~~~~~~~
 

--- a/graphql_jwt/settings.py
+++ b/graphql_jwt/settings.py
@@ -11,6 +11,8 @@ DEFAULTS = {
     'JWT_ISSUER': None,
     'JWT_LEEWAY': 0,
     'JWT_SECRET_KEY': settings.SECRET_KEY,
+    'JWT_PUBLIC_KEY': None,
+    'JWT_PRIVATE_KEY': None,
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': False,
     'JWT_EXPIRATION_DELTA': timedelta(seconds=60 * 5),

--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -36,7 +36,7 @@ def jwt_payload(user, context=None):
 def jwt_encode(payload, context=None):
     return jwt.encode(
         payload,
-        jwt_settings.JWT_SECRET_KEY,
+        jwt_settings.JWT_PRIVATE_KEY or jwt_settings.JWT_SECRET_KEY,
         jwt_settings.JWT_ALGORITHM,
     ).decode('utf-8')
 
@@ -44,7 +44,7 @@ def jwt_encode(payload, context=None):
 def jwt_decode(token, context=None):
     return jwt.decode(
         token,
-        jwt_settings.JWT_SECRET_KEY,
+        jwt_settings.JWT_PUBLIC_KEY or jwt_settings.JWT_SECRET_KEY,
         jwt_settings.JWT_VERIFY,
         options={
             'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION,

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 coverage>=4.4
+cryptography>=2.0.3
 pytest>=3.3.1
 pytest-cov>=2.4.0
 pytest-django>=3.1.2


### PR DESCRIPTION
ref #131, closes #148 

e.g.
```py
GRAPHQL_JWT = {
    'JWT_ALGORITHM': 'RS256',
    'JWT_PUBLIC_KEY': '...',
    'JWT_PRIVATE_KEY': '...',
}
```