### PR TITLE
Fixes #144: Decorator to check user's group permissions

### DIFF
--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -76,7 +76,7 @@ def check_group_permission(codename):
             for permission in permissions:
                 if permission.codename == codename:
                     return func(self, info, *args, **kwargs)
-            raise GraphQLError("The user's group doesn't have the required permission for this opeartion!")
+            raise GraphQLError("Group doesn't have the required permission")
         return wrapper
     return decorator
 

--- a/graphql_jwt/decorators.py
+++ b/graphql_jwt/decorators.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from graphene.utils.thenables import maybe_thenable
 from graphql.execution.base import ResolveInfo
+from graphql import GraphQLError
 
 from . import exceptions, signals
 from .refresh_token.shortcuts import create_refresh_token, refresh_token_lazy
@@ -25,6 +26,7 @@ __all__ = [
     'setup_jwt_cookie',
     'jwt_cookie',
     'ensure_token',
+    'check_group_permission'
 ]
 
 
@@ -52,6 +54,31 @@ def user_passes_test(test_func, exc=exceptions.PermissionDenied):
 login_required = user_passes_test(lambda u: u.is_authenticated)
 staff_member_required = user_passes_test(lambda u: u.is_staff)
 superuser_required = user_passes_test(lambda u: u.is_superuser)
+
+
+def check_group_permission(codename):
+    """
+    Decorator to check for user's group permissions
+    """
+    def decorator(func):
+        def wrapper(self, info, *args, **kwargs):
+            user = info.context.user
+            groups = user.groups.all()
+
+            if not groups:
+                raise GraphQLError("The user is not part of any group!")
+
+            permissions = []
+
+            for group in groups:
+                permissions.extend(group.permissions.all())
+
+            for permission in permissions:
+                if permission.codename == codename:
+                    return func(self, info, *args, **kwargs)
+            raise GraphQLError("The user's group doesn't have the required permission for this opeartion!")
+        return wrapper
+    return decorator
 
 
 def permission_required(perm):


### PR DESCRIPTION
Fixes #144 

## Problem

Currently, there is no inbuilt method or decorator to check for user's group permissions. So if in a scenario where we have permissions defined on a group level, we have to manually fetch the user's group, get the permission of that group and check whether the permission matches or not.

## Fix

This pull request adds a decorator `check_group_permission` using which we can check for permissions of a user's group. We just need to pass the `codename` of the permission as an argument to this decorator

## Usage

Suppose there are two groups - `teachers` and `students` and we want to see if a group has a permission codenamed `can_check_answer_sheets`. So if teacher John is currently logged in, we can check for his group's permission simply by doing

```python
from graphql_jwt.decorators import check_group_permission

class Something:

    @check_group_permission('can_check_answer_sheets')
    def mutate(self, info, input=None):
         .....
         ....
```