### PR TITLE
Removed deprecated providing_args from signal definitions.

### DIFF
--- a/graphql_jwt/signals.py
+++ b/graphql_jwt/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-token_issued = Signal(providing_args=['request', 'user'])
-token_refreshed = Signal(providing_args=['request', 'user'])
+token_issued = Signal(['request', 'user'])
+token_refreshed = Signal(['request', 'user'])


### PR DESCRIPTION
Depends on #223 
Closes #222 