### PR TITLE
Add JWT_COOKIE_SAMESITE property to deleted cookie

### DIFF
--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -137,8 +137,11 @@ def set_cookie(response, key, value, expires):
 
 
 def delete_cookie(response, key):
-    response.delete_cookie(
-        key,
-        path=jwt_settings.JWT_COOKIE_PATH,
-        domain=jwt_settings.JWT_COOKIE_DOMAIN,
-    )
+    kwargs = {
+        "path": jwt_settings.JWT_COOKIE_PATH,
+        "domain": jwt_settings.JWT_COOKIE_DOMAIN,
+    }
+    if django.VERSION >= (2, 1):
+        kwargs["samesite"] = jwt_settings.JWT_COOKIE_SAMESITE
+    
+    response.delete_cookie(key, **kwargs)


### PR DESCRIPTION
To delete a httponly cookie, the server responds with a cookie of which the expiration is in the past (https://stackoverflow.com/a/20320610/3179285)

In case of cross origin requests it's important that the SameSite attribute is also the same so I added this parameter to  delete_cookie.