### PR TITLE
Fix: graphql_auth incompatibility

### DIFF
--- a/graphql_jwt/mixins.py
+++ b/graphql_jwt/mixins.py
@@ -12,8 +12,8 @@ from .utils import get_payload, get_user_by_payload
 
 
 class JSONWebTokenMixin:
-    payload = GenericScalar(required=True)
-    refresh_expires_in = graphene.Int(required=True)
+    payload = GenericScalar(required=False)
+    refresh_expires_in = graphene.Int(required=False)
 
     @classmethod
     def Field(cls, *args, **kwargs):
@@ -41,7 +41,7 @@ class ObtainJSONWebTokenMixin(JSONWebTokenMixin):
 
 
 class VerifyMixin:
-    payload = GenericScalar(required=True)
+    payload = GenericScalar(required=False)
 
     @classmethod
     @ensure_token
@@ -105,7 +105,7 @@ class RefreshMixin(
 
 
 class DeleteJSONWebTokenCookieMixin:
-    deleted = graphene.Boolean(required=True)
+    deleted = graphene.Boolean(required=False)
 
     @classmethod
     def delete_cookie(cls, root, info, **kwargs):

--- a/graphql_jwt/refresh_token/mixins.py
+++ b/graphql_jwt/refresh_token/mixins.py
@@ -64,7 +64,7 @@ class RefreshTokenMixin:
 
 
 class RevokeMixin:
-    revoked = graphene.Int(required=True)
+    revoked = graphene.Int(required=False)
 
     @classmethod
     @ensure_refresh_token
@@ -76,7 +76,7 @@ class RevokeMixin:
 
 
 class DeleteRefreshTokenCookieMixin:
-    deleted = graphene.Boolean(required=True)
+    deleted = graphene.Boolean(required=False)
 
     @classmethod
     def delete_cookie(cls, root, info, **kwargs):


### PR DESCRIPTION
With the new release of gql_jwt all the output fields are required, 
therefore implementing custom output by the user is impossible because graphene will raise 
None  on non field Error i.e:
 
![image](https://user-images.githubusercontent.com/88795475/158702099-6e24b4c5-adb9-476c-a9ff-974edd57b558.png)

And the desired result would be:

![image](https://user-images.githubusercontent.com/88795475/158702499-248af26c-c4bf-456f-a5f9-c37221c1e7ce.png)


