### PR TITLE
fix: added samesite attribute to delete_cookie

### DIFF
--- a/graphql_jwt/utils.py
+++ b/graphql_jwt/utils.py
@@ -137,8 +137,13 @@ def set_cookie(response, key, value, expires):
 
 
 def delete_cookie(response, key):
+    kwargs = {
+        "path": jwt_settings.JWT_COOKIE_PATH,
+        "domain": jwt_settings.JWT_COOKIE_DOMAIN,
+    }
+    if django.VERSION >= (2, 1):
+        kwargs["samesite"] = jwt_settings.JWT_COOKIE_SAMESITE
+
     response.delete_cookie(
-        key,
-        path=jwt_settings.JWT_COOKIE_PATH,
-        domain=jwt_settings.JWT_COOKIE_DOMAIN,
+        key, **kwargs
     )


### PR DESCRIPTION
Cookie delete requests are blocked by browsers without **samesite** attribute set for **cross-site** usage. 
delete_cookie function is working fine with this attribute set.